### PR TITLE
Add pt-BR Translation to LLM Vision Timeline Card

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Alternatively you can add the url of this repository to the custom respositories
 | number_of_events  | How many events to show                                                                  | 5                            |
 | calendar_entity   | LLM Vision Timeline Entity (needs to be set up in LLM Vision Settings first)             | calendar.llm_vision_timeline |
 | refresh_interval  | Refresh Interval (in seconds)                                                            | 10                           |
-| language          | Language used for UI and generate icons (supports: `en`, `de`, `nl`, `fr`, `es`)         | `en`                         |
+| language          | Language used for UI and generate icons (supports: `en`, `de`, `nl`, `fr`, `es`, `pt`)         | `en`                         |
 
 ## Support
 You can support this project by starring this GitHub repository. If you want, you can also buy me a coffee here:  

--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -4,6 +4,7 @@ import { de } from './de.js';
 import { nl } from './nl.js';
 import { en } from './en.js';
 import { es } from './es.js';
+import { pt } from './pt.js';
 
 export function getIcon(title, lang = 'en') {
     let categories;
@@ -19,6 +20,8 @@ export function getIcon(title, lang = 'en') {
             categories = fr.categories;
         } else if (lang === 'es') {
             categories = es.categories;
+        } else if (lang === 'pt') {
+            categories = pt.categories;
         } else {
             throw new Error(`Unsupported language: ${lang}`);
         }
@@ -47,6 +50,7 @@ const translations = {
     nl: nl.text,
     fr: fr.text,
     es: es.text,
+    pt: pt.text,
 };
 
 export function translate(key, language) {

--- a/dist/pt.js
+++ b/dist/pt.js
@@ -1,0 +1,77 @@
+export const pt = {
+    "text": {
+        "noEvents": "Nenhum Evento",
+        "today": "Hoje",
+        "yesterday": "Ontem"
+    },
+    "categories": {
+        "people": {
+            "objects": {
+                "pessoa": "mdi:walk",
+                "indivíduo": "mdi:walk",
+                "figura": "mdi:walk",
+                "pessoas": "mdi:walk",
+                "criança": "mdi:walk",
+                "mulher": "mdi:walk",
+                "homem": "mdi:walk",
+                "humano": "mdi:walk"
+            }
+        },
+        "vehicles": {
+            "objects": {
+                "entregador": "mdi:truck-delivery",
+                "carteiro": "mdi:truck-delivery",
+                "bicicleta": "mdi:bike",
+                "moto": "mdi:motorbike",
+                "motocicleta": "mdi:motorbike",
+                "onibus": "mdi:bus",
+                "carro": "mdi:car",
+                "van": "mdi:car",
+                "suv": "mdi:car",
+                "veículo": "mdi:car",
+                "caminhão": "mdi:truck",
+                "rua": "mdi:road-variant",
+                "calçada": "mdi:road-variant"
+            }
+        },
+        "animals": {
+            "objects": {
+                "cão": "mdi:dog",
+                "gato": "mdi:cat",
+                "pássaro": "mdi:duck",
+                "animal": "mdi:dog"
+            }
+        },
+        "packages": {
+            "objects": {
+                "caixa": "mdi:package-variant-closed",
+                "pacote": "mdi:package-variant-closed",
+                "encomenda": "mdi:package-variant-closed",
+                "carta": "mdi:email"
+            }
+        },
+        "entities": {
+            "objects": {
+                "câmera": "mdi:cctv",
+                "sensor": "mdi:access-point",
+                "luz": "mdi:lightbulb",
+                "chave": "mdi:key",
+                "fechadura": "mdi:lock",
+                "alarme": "mdi:alarm-light",
+                "casa": "mdi:home",
+                "varanda": "mdi:door-closed",
+                "porta": "mdi:door-closed",
+                "janela": "mdi:window-closed-variant"
+            }
+        },
+        "nature": {
+            "objects": {
+                "jardim": "mdi:flower",
+                "planta": "mdi:flower",
+                "flor": "mdi:flower",
+                "árvore": "mdi:tree"
+            }
+        }
+    },
+    "regex": ""
+}

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
     "name": "llmvision-card",
-    "version": "1.4.1"
+    "version": "1.4.2"
 }


### PR DESCRIPTION
This pull request introduces Brazilian Portuguese (pt-BR) translation support to the LLM Vision Timeline Card, enhancing accessibility for Portuguese-speaking Home Assistant users. The Timeline Card displays events analyzed by the LLM Vision integration, providing users with a clear overview of activities around their home. 

**Changes:**

- Added pt-BR translation to the card's configuration, enabling users to view event timelines in Brazilian Portuguese.

**Benefits:**

- Improves user experience for Portuguese-speaking users by presenting information in their native language.

- Expands the card's usability within the Brazilian Home Assistant community.

This update aligns with the project's goal of providing an intelligent and accessible Home Assistant integration for a diverse user base.