### PR TITLE
1.4.2 beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Alternatively you can add the url of this repository to the custom respositories
 3. Add the card to your dashboard
 
 ## Configuration
+>[!TIP]
+>If both `number_of_events` and `number_of_hours` are set, the card will show events that occurred within the past specified number of hours, up to the specified number of events.
+
 
 | Parameter         | Description                                                                                                 | Default                      |
 |-------------------|-------------------------------------------------------------------------------------------------------------|------------------------------|
@@ -55,7 +58,7 @@ Alternatively you can add the url of this repository to the custom respositories
 | number_of_hours   | Show events that occurred within the past specified number of hours.                                        | 10                           |
 | calendar_entity   | LLM Vision Timeline Entity (needs to be set up in LLM Vision Settings first)                                |`calendar.llm_vision_timeline`|
 | refresh_interval  | Refresh Interval (in seconds)                                                                               | 10                           |
-| language          | Language used for UI and generate icons (supports: `en`, `de`, `nl`, `fr`, `es`, `pt`, `pl`, `sv`, `it`)    | `en`                         |
+| language          | Language used for UI and generate icons (supports: `de`, `en`, `es`, `fr`, `it`, `nl`, `pl`, `pt`, `sv`)    | `en`                         |
 
 ## Support
 You can support this project by starring this GitHub repository. If you want, you can also buy me a coffee here:  

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Alternatively you can add the url of this repository to the custom respositories
 | number_of_events  | How many events to show                                                                  | 5                            |
 | calendar_entity   | LLM Vision Timeline Entity (needs to be set up in LLM Vision Settings first)             | calendar.llm_vision_timeline |
 | refresh_interval  | Refresh Interval (in seconds)                                                            | 10                           |
-| language          | Language used for UI and generate icons (supports: `en`, `de`, `nl`, `fr`, `es`, `pt`)         | `en`                         |
+| language          | Language used for UI and generate icons (supports: `en`, `de`, `nl`, `fr`, `es`, `pt`, `pl`)         | `en`                         |
 
 ## Support
 You can support this project by starring this GitHub repository. If you want, you can also buy me a coffee here:  

--- a/README.md
+++ b/README.md
@@ -54,8 +54,7 @@ Alternatively you can add the url of this repository to the custom respositories
 | number_of_events  | How many events to show. Maximum is 10.                                                         | 5                            |
 | calendar_entity   | LLM Vision Timeline Entity (needs to be set up in LLM Vision Settings first)                    |`calendar.llm_vision_timeline`|
 | refresh_interval  | Refresh Interval (in seconds)                                                                   | 10                           |
-| language          | Language used for UI and generate icons (supports: `en`, `de`, `nl`, `fr`, `es`, `pt`, `pl`, `sv`)    | `en`                         |
-
+| language          | Language used for UI and generate icons (supports: `en`, `de`, `nl`, `fr`, `es`, `pt`, `pl`, `sv`, `it`)    | `en`                         |
 
 ## Support
 You can support this project by starring this GitHub repository. If you want, you can also buy me a coffee here:  

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <h1 align=center>Timeline Card</h1>
 <p align=center>
 <img src=https://img.shields.io/badge/HACS-Custom-orange.svg>
-<img src=https://img.shields.io/badge/version-1.4.0-blue>
+<img src=https://img.shields.io/badge/version-1.4.2-blue>
 <img src="https://img.shields.io/maintenance/yes/2025.svg">
 <img alt="Issues" src="https://img.shields.io/github/issues/valentinfrlch/llmvision-card?color=0088ff"/>
 <img alt="Static Badge" src="https://img.shields.io/badge/support-buymeacoffee?logo=buymeacoffee&logoColor=black&color=%23FFDD00&link=https%3A%2F%2Fbuymeacoffee.com%2Fvalentinfrlch">
@@ -49,12 +49,12 @@ Alternatively you can add the url of this repository to the custom respositories
 
 ## Configuration
 
-| Parameter         | Description                                                                              | Default                      |
-|-------------------|------------------------------------------------------------------------------------------|------------------------------|
-| number_of_events  | How many events to show                                                                  | 5                            |
-| calendar_entity   | LLM Vision Timeline Entity (needs to be set up in LLM Vision Settings first)             | calendar.llm_vision_timeline |
-| refresh_interval  | Refresh Interval (in seconds)                                                            | 10                           |
-| language          | Language used for UI and generate icons (supports: `en`, `de`, `nl`, `fr`, `es`, `pt`, `pl`)         | `en`                         |
+| Parameter         | Description                                                                                     | Default                      |
+|-------------------|-------------------------------------------------------------------------------------------------|------------------------------|
+| number_of_events  | How many events to show. Maximum is 10.                                                         | 5                            |
+| calendar_entity   | LLM Vision Timeline Entity (needs to be set up in LLM Vision Settings first)                    |`calendar.llm_vision_timeline`|
+| refresh_interval  | Refresh Interval (in seconds)                                                                   | 10                           |
+| language          | Language used for UI and generate icons (supports: `en`, `de`, `nl`, `fr`, `es`, `pt`, `pl`)    | `en`                         |
 
 ## Support
 You can support this project by starring this GitHub repository. If you want, you can also buy me a coffee here:  

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Alternatively you can add the url of this repository to the custom respositories
 | number_of_events  | How many events to show. Maximum is 10.                                                         | 5                            |
 | calendar_entity   | LLM Vision Timeline Entity (needs to be set up in LLM Vision Settings first)                    |`calendar.llm_vision_timeline`|
 | refresh_interval  | Refresh Interval (in seconds)                                                                   | 10                           |
-| language          | Language used for UI and generate icons (supports: `en`, `de`, `nl`, `fr`, `es`, `pt`, `pl`)    | `en`                         |
+| language          | Language used for UI and generate icons (supports: `en`, `de`, `nl`, `fr`, `es`, `pt`, `pl`, `sv`)    | `en`                         |
+
 
 ## Support
 You can support this project by starring this GitHub repository. If you want, you can also buy me a coffee here:  

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
   <a href="https://llmvision.org"> Visit Website →</a>
     </p>
 
-<img src="https://github.com/user-attachments/assets/97f6e608-bdf3-44d1-89f1-fd89cda7b764" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="50%" height="auto" />
+<img src="https://github.com/user-attachments/assets/97f6e608-bdf3-44d1-89f1-fd89cda7b764" width="50%" height="auto" />
 
 ## Prerequisites
 1. [LLM Vision](https://github.com/valentinfrlch/ha-llmvision) set up in Home Assistant
@@ -49,11 +49,12 @@ Alternatively you can add the url of this repository to the custom respositories
 
 ## Configuration
 
-| Parameter         | Description                                                                                     | Default                      |
-|-------------------|-------------------------------------------------------------------------------------------------|------------------------------|
-| number_of_events  | How many events to show. Maximum is 10.                                                         | 5                            |
-| calendar_entity   | LLM Vision Timeline Entity (needs to be set up in LLM Vision Settings first)                    |`calendar.llm_vision_timeline`|
-| refresh_interval  | Refresh Interval (in seconds)                                                                   | 10                           |
+| Parameter         | Description                                                                                                 | Default                      |
+|-------------------|-------------------------------------------------------------------------------------------------------------|------------------------------|
+| number_of_events  | How many events to show. Maximum is 10.                                                                     | 5                            |
+| number_of_hours   | Show events that occurred within the past specified number of hours.                                        | 10                           |
+| calendar_entity   | LLM Vision Timeline Entity (needs to be set up in LLM Vision Settings first)                                |`calendar.llm_vision_timeline`|
+| refresh_interval  | Refresh Interval (in seconds)                                                                               | 10                           |
 | language          | Language used for UI and generate icons (supports: `en`, `de`, `nl`, `fr`, `es`, `pt`, `pl`, `sv`, `it`)    | `en`                         |
 
 ## Support

--- a/dist/de.js
+++ b/dist/de.js
@@ -12,7 +12,9 @@ export const de = {
                 "kind": "mdi:walk",
                 "frau": "mdi:walk",
                 "mann": "mdi:walk",
-                "mensch": "mdi:walk"
+                "mensch": "mdi:walk",
+                "radfahrer": "mdi:bike",
+                "fahrradfahrer": "mdi:bike"
             }
         },
         "vehicles": {
@@ -28,6 +30,7 @@ export const de = {
                 "fahrzeug": "mdi:car",
                 "lastwagen": "mdi:truck",
                 "strasse": "mdi:road-variant",
+                "weg": "mdi:road-variant",
                 "einfahrt": "mdi:road-variant"
             }
         },

--- a/dist/de.js
+++ b/dist/de.js
@@ -1,6 +1,7 @@
 export const de = {
     "text": {
         "noEvents": "Keine Ereignisse",
+        "noEventsHours": "Keine Ereignisse in den letzten {hours} Stunden",
         "today": "Heute",
         "yesterday": "Gestern"
     },

--- a/dist/en.js
+++ b/dist/en.js
@@ -1,6 +1,7 @@
 export const en = {
     "text": {
         "noEvents": "No events",
+        "noEventsHours": "No events in the last {hours} hours",
         "today": "Today",
         "yesterday": "Yesterday"
     },

--- a/dist/en.js
+++ b/dist/en.js
@@ -14,7 +14,8 @@ export const en = {
                 "child": "mdi:walk",
                 "woman": "mdi:walk",
                 "man": "mdi:walk",
-                "human": "mdi:walk"
+                "human": "mdi:walk",
+                "cyclist": "mdi:bike",
             }
         },
         "vehicles": {
@@ -32,6 +33,7 @@ export const en = {
                 "vehicle": "mdi:car",
                 "truck": "mdi:truck",
                 "street": "mdi:road-variant",
+                "path": "mdi:road-variant",
                 "driveway": "mdi:road-variant"
             }
         },

--- a/dist/es.js
+++ b/dist/es.js
@@ -12,7 +12,8 @@ export const es = {
                 "niño": "mdi:walk",
                 "mujer": "mdi:walk",
                 "hombre": "mdi:walk",
-                "humano": "mdi:walk"
+                "humano": "mdi:walk",
+                "ciclista": "mdi:bike"
             }
         },
         "vehicles": {
@@ -28,6 +29,7 @@ export const es = {
                 "vehículo": "mdi:car",
                 "camión": "mdi:truck",
                 "calle": "mdi:road-variant",
+                "carretera": "mdi:road-variant",
                 "calzada": "mdi:road-variant"
             }
         },

--- a/dist/es.js
+++ b/dist/es.js
@@ -1,6 +1,7 @@
 export const es = {
     "text": {
         "noEvents": "No hay eventos",
+        "noEventsHours": "No hay eventos en las últimas {hours} horas",
         "today": "Hoy",
         "yesterday": "Ayer"
     },

--- a/dist/fr.js
+++ b/dist/fr.js
@@ -1,6 +1,7 @@
 export const fr = {
     "text": {
         "noEvents": "Aucun événement",
+        "noEventsHours": "Aucun événement dans les dernières {hours} heures",
         "today": "Aujourd'hui",
         "yesterday": "Hier"
     },

--- a/dist/fr.js
+++ b/dist/fr.js
@@ -12,7 +12,8 @@ export const fr = {
                 "enfant": "mdi:walk",
                 "femme": "mdi:walk",
                 "homme": "mdi:walk",
-                "humain": "mdi:walk"
+                "humain": "mdi:walk",
+                "cycliste": "mdi:bike"
             }
         },
         "vehicles": {
@@ -28,6 +29,7 @@ export const fr = {
                 "véhicule": "mdi:car",
                 "camion": "mdi:truck",
                 "rue": "mdi:road-variant",
+                "chemin": "mdi:road-variant",
                 "voie": "mdi:road-variant"
             }
         },

--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -7,6 +7,7 @@ import { es } from './es.js';
 import { pt } from './pt.js';
 import { sv } from './sv.js';
 import { pl } from './pl.js';
+import { it } from './it.js';
 
 export function getIcon(title, lang = 'en') {
     let categories;
@@ -26,6 +27,8 @@ export function getIcon(title, lang = 'en') {
             categories = pt.categories;
         } else if (lang === 'sv') {
             categories = sv.categories;
+        } else if (lang === 'it') {
+            categories = it.categories;
         } else if (lang === 'pl') {
             categories = pl.categories;
         } else {
@@ -59,6 +62,7 @@ const translations = {
     pt: pt.text,
     sv: sv.text,
     pl: pl.text,
+    it: it.text,
 };
 
 export function translate(key, language) {

--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -5,6 +5,7 @@ import { nl } from './nl.js';
 import { en } from './en.js';
 import { es } from './es.js';
 import { pt } from './pt.js';
+import { sv } from './sv.js';
 import { pl } from './pl.js';
 
 export function getIcon(title, lang = 'en') {
@@ -23,6 +24,8 @@ export function getIcon(title, lang = 'en') {
             categories = es.categories;
         } else if (lang === 'pt') {
             categories = pt.categories;
+        } else if (lang === 'sv') {
+            categories = sv.categories;
         } else if (lang === 'pl') {
             categories = pl.categories;
         } else {
@@ -54,6 +57,7 @@ const translations = {
     fr: fr.text,
     es: es.text,
     pt: pt.text,
+    sv: sv.text,
     pl: pl.text,
 };
 

--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -5,6 +5,7 @@ import { nl } from './nl.js';
 import { en } from './en.js';
 import { es } from './es.js';
 import { pt } from './pt.js';
+import { pl } from './pl.js';
 
 export function getIcon(title, lang = 'en') {
     let categories;
@@ -22,6 +23,8 @@ export function getIcon(title, lang = 'en') {
             categories = es.categories;
         } else if (lang === 'pt') {
             categories = pt.categories;
+        } else if (lang === 'pl') {
+            categories = pl.categories;
         } else {
             throw new Error(`Unsupported language: ${lang}`);
         }
@@ -51,6 +54,7 @@ const translations = {
     fr: fr.text,
     es: es.text,
     pt: pt.text,
+    pl: pl.text,
 };
 
 export function translate(key, language) {

--- a/dist/it.js
+++ b/dist/it.js
@@ -1,6 +1,7 @@
 export const it = {
     "text": {
         "noEvents": "Nessun Evento",
+        "noEventsHours": "Nessun Evento nelle ultime {hours} ore",
         "today": "Oggi",
         "yesterday": "Ieri"
     },

--- a/dist/it.js
+++ b/dist/it.js
@@ -1,0 +1,75 @@
+export const it = {
+    "text": {
+        "noEvents": "Nessun Evento",
+        "today": "Oggi",
+        "yesterday": "Ieri"
+    },
+    "categories": {
+        "people": {
+            "objects": {
+                "persona": "mdi:walk",
+                "gente": "mdi:walk",
+                "bambino": "mdi:walk",
+                "donna": "mdi:walk",
+                "uomo": "mdi:walk",
+                "umano": "mdi:walk"
+            }
+        },
+        "vehicles": {
+            "objects": {
+                "furgone": "mdi:truck-delivery",
+                "postino": "mdi:truck-delivery",
+                "bicicletta": "mdi:bike",
+                "motocicletta": "mdi:motorbike",
+                "autobus": "mdi:bus",
+                "macchina": "mdi:car",
+                "fuoristrada": "mdi:car",
+                "suv": "mdi:car",
+                "veicolo": "mdi:car",
+                "camion": "mdi:truck",
+                "strada": "mdi:road-variant",
+                "vialetto": "mdi:road-variant"
+            }
+        },
+        "animals": {
+            "objects": {
+                "cane": "mdi:dog",
+                "gatto": "mdi:cat",
+                "gatti": "mdi:cat",
+                "papero": "mdi:duck",
+                "cucciolo": "mdi:dog",
+                "animale": "mdi:dog"
+            }
+        },
+        "packages": {
+            "objects": {
+                "cassa": "mdi:package-variant-closed",
+                "pacchetto": "mdi:package-variant-closed",
+                "posta": "mdi:email"
+            }
+        },
+        "entities": {
+            "objects": {
+                "telecamera": "mdi:cctv",
+                "sensore": "mdi:access-point",
+                "luce": "mdi:lightbulb",
+                "chiave": "mdi:key",
+                "serratura": "mdi:lock",
+                "allarme": "mdi:alarm-light",
+                "casa": "mdi:home",
+                "entrata": "mdi:door-closed",
+                "porta": "mdi:door-closed",
+                "finestra": "mdi:window-closed-variant"
+            }
+        },
+        "nature": {
+            "objects": {
+                "giardino": "mdi:flower",
+                "pianta": "mdi:flower",
+                "fiore": "mdi:flower",
+                "albero": "mdi:tree"
+            }
+        }
+    },
+    "regex": "`\\b${key}(it)?\\b`, 'i'"
+};

--- a/dist/llmvision-card.js
+++ b/dist/llmvision-card.js
@@ -150,6 +150,10 @@ class LLMVisionCard extends HTMLElement {
         if (numberOfHours) {
             const cutoffTime = new Date().getTime() - numberOfHours * 60 * 60 * 1000;
             eventDetails = eventDetails.filter(detail => new Date(detail.startTime).getTime() >= cutoffTime);
+            if (numberOfEvents) {
+                // Limit the number of events to display if numberOfEvents is set
+                eventDetails = eventDetails.slice(0, numberOfEvents);
+            }
         }
 
         // Sort event details by start time

--- a/dist/llmvision-card.js
+++ b/dist/llmvision-card.js
@@ -172,6 +172,18 @@ class LLMVisionCard extends HTMLElement {
             this.content.appendChild(loadingContainer);
         }
 
+        if (numberOfHours && eventDetails.length === 0) {
+            const noEventsContainer = document.createElement('div');
+            const noEventsMessage = translate('noEventsHours', this.language).replace('{hours}', numberOfHours);
+            noEventsContainer.innerHTML = `
+                <div class="event-container" style="display: flex; justify-content: center; align-items: center; height: 100%;">
+                    <h3>${noEventsMessage}</h3>
+                </div>
+            `;
+            this.content.appendChild(noEventsContainer);
+            return;
+        }
+
         // Add events and key frames for the specified number of events
         let lastDate = '';
 

--- a/dist/llmvision-card.js
+++ b/dist/llmvision-card.js
@@ -21,9 +21,6 @@ class LLMVisionCard extends HTMLElement {
         if (!this.number_of_events && !this.number_of_hours) {
             throw new Error('Either number_of_events or number_of_hours needs to be set.');
         }
-        if (this.number_of_events && this.number_of_hours) {
-            throw new Warning('Both number_of_events and number_of_hours are set. Card will show only events that match both filters.');
-        }
         if (this.number_of_events < 1) {
             throw new Error('number_of_events must be greater than 0.');
         }

--- a/dist/llmvision-card.js
+++ b/dist/llmvision-card.js
@@ -9,11 +9,11 @@ class LLMVisionCard extends HTMLElement {
     // required
     setConfig(config) {
         this.config = config;
-        this.calendar_entity = config.calendar_entity || 'calendar.llm_vision_timeline';
-        this.number_of_events = config.number_of_events || 5;
+        this.calendar_entity = config.calendar_entity;
+        this.number_of_events = config.number_of_events;
         this.number_of_hours = config.number_of_hours;
-        this.refresh_interval = config.refresh_interval || 10;
-        this.language = config.language || 'en';
+        this.refresh_interval = config.refresh_interval;
+        this.language = config.language;
 
         if (!this.calendar_entity) {
             throw new Error('You need to define the timeline (calendar entity) in the card configuration.');
@@ -402,7 +402,7 @@ class LLMVisionCard extends HTMLElement {
     }
 
     static getStubConfig() {
-        return { calendar_entity: 'calendar.llm_vision_timeline', number_of_events: 5, refresh_interval: 10 };
+        return { calendar_entity: 'calendar.llm_vision_timeline', number_of_events: 5, refresh_interval: 10, language: 'en' };
     }
 }
 

--- a/dist/llmvision-card.js
+++ b/dist/llmvision-card.js
@@ -22,7 +22,7 @@ class LLMVisionCard extends HTMLElement {
             throw new Error('Either number_of_events or number_of_hours needs to be set.');
         }
         if (this.number_of_events && this.number_of_hours) {
-            throw new Error('You can only set either number_of_events or number_of_hours, not both.');
+            throw new Warning('Both number_of_events and number_of_hours are set. Card will show only events that match both filters.');
         }
         if (this.number_of_events < 1) {
             throw new Error('number_of_events must be greater than 0.');

--- a/dist/llmvision-card.js
+++ b/dist/llmvision-card.js
@@ -324,44 +324,59 @@ class LLMVisionCard extends HTMLElement {
             </style>
         `;
 
+        // Push a new history state
+        if (!history.state || !history.state.popupOpen) {
+            history.pushState({ popupOpen: true }, '');
+        }
+
+        // Define the popstate handler
+        const popstateHandler = () => {
+            this.closePopup(popup, popstateHandler);
+        };
+
+        // Add the popstate event listener
+        window.addEventListener('popstate', popstateHandler);
+
+        // Add other event listeners for closing the popup
+        popup.querySelector('.close-popup').addEventListener('click', () => {
+            this.closePopup(popup, popstateHandler);
+        });
+
+        popup.querySelector('.popup-overlay').addEventListener('click', (event) => {
+            if (event.target === popup.querySelector('.popup-overlay')) {
+                this.closePopup(popup, popstateHandler);
+            }
+        });
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape') {
+                this.closePopup(popup, popstateHandler);
+            }
+        });
+
+        // Add the popup to the DOM
         document.body.appendChild(popup);
-        history.pushState({ popupOpen: true }, '');
 
         // Add the show class to trigger the animation
         requestAnimationFrame(() => {
             popup.querySelector('.popup-overlay').classList.add('show');
         });
-
-        popup.querySelector('.close-popup').addEventListener('click', () => {
-            this.closePopup(popup);
-        });
-
-        popup.querySelector('.popup-overlay').addEventListener('click', (event) => {
-            if (event.target === popup.querySelector('.popup-overlay')) {
-                this.closePopup(popup);
-            }
-        });
-
-        // Add event listener for Escape key
-        document.addEventListener('keydown', (event) => {
-            if (event.key === 'Escape') {
-                this.closePopup(popup);
-            }
-        });
-
-        // add event listener for 'back' button on android
-        window.addEventListener('popstate', () => {
-            this.closePopup(popup);
-        });
     }
 
-    closePopup(popup) {
+    closePopup(popup, popstateHandler) {
         // Remove the show class to trigger the closing animation
         popup.querySelector('.popup-overlay').classList.remove('show');
         popup.querySelector('.popup-overlay').addEventListener('transitionend', () => {
             document.body.removeChild(popup);
         }, { once: true });
-        history.back();
+
+        // Clean up the history state
+        if (history.state && history.state.popupOpen) {
+            history.replaceState(null, ''); // Replace the current state to avoid navigating back
+        }
+
+        // Remove the popstate event listener
+        window.removeEventListener('popstate', popstateHandler);
     }
 
     static getStubConfig() {

--- a/dist/llmvision-card.js
+++ b/dist/llmvision-card.js
@@ -325,6 +325,7 @@ class LLMVisionCard extends HTMLElement {
         `;
 
         document.body.appendChild(popup);
+        history.pushState({ popupOpen: true }, '');
 
         // Add the show class to trigger the animation
         requestAnimationFrame(() => {
@@ -360,6 +361,7 @@ class LLMVisionCard extends HTMLElement {
         popup.querySelector('.popup-overlay').addEventListener('transitionend', () => {
             document.body.removeChild(popup);
         }, { once: true });
+        history.back();
     }
 
     static getStubConfig() {

--- a/dist/llmvision-card.js
+++ b/dist/llmvision-card.js
@@ -137,7 +137,7 @@ class LLMVisionCard extends HTMLElement {
         const cameraNames = (calendarEntity.attributes.camera_names || []).slice()
         const startTimes = (calendarEntity.attributes.starts || []).slice()
 
-        const eventDetails = events.map((event, index) => {
+        let eventDetails = events.map((event, index) => {
             const cameraEntity = hass.states[cameraNames[index]];
             const cameraFriendlyName = cameraEntity ? cameraEntity.attributes.friendly_name : '';
             return {
@@ -187,7 +187,6 @@ class LLMVisionCard extends HTMLElement {
             const { icon, backgroundColor, iconColor } = getIcon(event, this.language);
             const secondaryText = cameraName ? `${formattedTime} • ${cameraName}` : formattedTime;
 
-            // TODO: Get config dir path from Home Assistant
             keyFrame = keyFrame.replace('/config/www/', '/local/');
 
             // Determine the date label

--- a/dist/nl.js
+++ b/dist/nl.js
@@ -1,6 +1,7 @@
 export const nl = {
     "text": {
         "noEvents": "Geen evenementen",
+        "noEventsHours": "Geen evenementen in de afgelopen {hours} uur",
         "today": "Vandaag",
         "yesterday": "Gisteren"
     },

--- a/dist/nl.js
+++ b/dist/nl.js
@@ -14,7 +14,8 @@ export const nl = {
                 "kind": "mdi:walk",
                 "vrouw": "mdi:walk",
                 "man": "mdi:walk",
-                "mens": "mdi:walk"
+                "mens": "mdi:walk",
+                "fietser": "mdi:bike"
             }
         },
         "vehicles": {
@@ -31,6 +32,7 @@ export const nl = {
                 "voertuig": "mdi:car",
                 "vrachtwagen": "mdi:truck",
                 "straat": "mdi:road-variant",
+                "weg": "mdi:road-variant",
                 "oprit": "mdi:road-variant"
             }
         },

--- a/dist/pl.js
+++ b/dist/pl.js
@@ -1,0 +1,81 @@
+export const pl = {
+  "text": {
+      "noEvents": "Brak aktywnosci",
+      "today": "Dzis",
+      "yesterday": "Wczoraj"
+  },
+  "categories": {
+      "people": {
+          "objects": {
+              "osoba": "mdi:walk",
+              "jednostka": "mdi:walk",
+              "postac": "mdi:walk",
+              "ludzie": "mdi:walk",
+              "dziecko": "mdi:walk",
+              "kobieta": "mdi:walk",
+              "mezczyzna": "mdi:walk",
+              "czlowiek": "mdi:walk"
+          }
+      },
+      "vehicles": {
+          "objects": {
+              "kurier": "mdi:truck-delivery",
+              "listonosz": "mdi:truck-delivery",
+              "rower": "mdi:bike",
+              "skuter": "mdi:motorbike",
+              "motocykl": "mdi:motorbike",
+              "autobus": "mdi:bus",
+              "samochod": "mdi:car",
+              "dostawczak": "mdi:car",
+              "SUV": "mdi:car",
+              "pojazd": "mdi:car",
+              "ciezarowka": "mdi:truck",
+              "ulica": "mdi:road-variant",
+              "podjazd": "mdi:road-variant"
+          }
+      },
+      "animals": {
+          "objects": {
+              "pies": "mdi:dog",
+              "kot": "mdi:cat",
+              "kotek": "mdi:cat",
+              "piesek": "mdi:dog",
+              "ptak": "mdi:duck",
+              "zwierze": "mdi:dog"
+          }
+      },
+      "packages": {
+          "objects": {
+              "pudelko": "mdi:package-variant-closed",
+              "paczka": "mdi:package-variant-closed",
+              "przesylka": "mdi:package-variant-closed",
+              "list": "mdi:email"
+          }
+      },
+      "entities": {
+          "objects": {
+              "kamera": "mdi:cctv",
+              "czujnik": "mdi:access-point",
+              "swiatlo": "mdi:lightbulb",
+              "klucz": "mdi:key",
+              "zamek": "mdi:lock",
+              "alarm": "mdi:alarm-light",
+              "dom": "mdi:home",
+              "weranda": "mdi:door-closed",
+              "drzwi": "mdi:door-closed",
+              "okno": "mdi:window-closed-variant",
+              "brama": "mdi:gate",
+              "bramy": "mdi:gate"
+          }
+      },
+      "nature": {
+          "objects": {
+              "ogrod": "mdi:flower",
+              "roslina": "mdi:flower",
+              "kwiat": "mdi:flower",
+              "drzewo": "mdi:tree"
+          }
+      }
+  },
+  "regex": ""
+};

--- a/dist/pl.js
+++ b/dist/pl.js
@@ -1,81 +1,83 @@
 export const pl = {
-  "text": {
-      "noEvents": "Brak aktywnosci",
-      "today": "Dzis",
-      "yesterday": "Wczoraj"
-  },
-  "categories": {
-      "people": {
-          "objects": {
-              "osoba": "mdi:walk",
-              "jednostka": "mdi:walk",
-              "postac": "mdi:walk",
-              "ludzie": "mdi:walk",
-              "dziecko": "mdi:walk",
-              "kobieta": "mdi:walk",
-              "mezczyzna": "mdi:walk",
-              "czlowiek": "mdi:walk"
-          }
-      },
-      "vehicles": {
-          "objects": {
-              "kurier": "mdi:truck-delivery",
-              "listonosz": "mdi:truck-delivery",
-              "rower": "mdi:bike",
-              "skuter": "mdi:motorbike",
-              "motocykl": "mdi:motorbike",
-              "autobus": "mdi:bus",
-              "samochod": "mdi:car",
-              "dostawczak": "mdi:car",
-              "SUV": "mdi:car",
-              "pojazd": "mdi:car",
-              "ciezarowka": "mdi:truck",
-              "ulica": "mdi:road-variant",
-              "podjazd": "mdi:road-variant"
-          }
-      },
-      "animals": {
-          "objects": {
-              "pies": "mdi:dog",
-              "kot": "mdi:cat",
-              "kotek": "mdi:cat",
-              "piesek": "mdi:dog",
-              "ptak": "mdi:duck",
-              "zwierze": "mdi:dog"
-          }
-      },
-      "packages": {
-          "objects": {
-              "pudelko": "mdi:package-variant-closed",
-              "paczka": "mdi:package-variant-closed",
-              "przesylka": "mdi:package-variant-closed",
-              "list": "mdi:email"
-          }
-      },
-      "entities": {
-          "objects": {
-              "kamera": "mdi:cctv",
-              "czujnik": "mdi:access-point",
-              "swiatlo": "mdi:lightbulb",
-              "klucz": "mdi:key",
-              "zamek": "mdi:lock",
-              "alarm": "mdi:alarm-light",
-              "dom": "mdi:home",
-              "weranda": "mdi:door-closed",
-              "drzwi": "mdi:door-closed",
-              "okno": "mdi:window-closed-variant",
-              "brama": "mdi:gate",
-              "bramy": "mdi:gate"
-          }
-      },
-      "nature": {
-          "objects": {
-              "ogrod": "mdi:flower",
-              "roslina": "mdi:flower",
-              "kwiat": "mdi:flower",
-              "drzewo": "mdi:tree"
-          }
-      }
-  },
-  "regex": ""
+    "text": {
+        "noEvents": "Brak aktywnosci",
+        "today": "Dzis",
+        "yesterday": "Wczoraj"
+    },
+    "categories": {
+        "people": {
+            "objects": {
+                "osoba": "mdi:walk",
+                "jednostka": "mdi:walk",
+                "postac": "mdi:walk",
+                "ludzie": "mdi:walk",
+                "dziecko": "mdi:walk",
+                "kobieta": "mdi:walk",
+                "mezczyzna": "mdi:walk",
+                "czlowiek": "mdi:walk",
+                "rowerzysta": "mdi:bike"
+            }
+        },
+        "vehicles": {
+            "objects": {
+                "kurier": "mdi:truck-delivery",
+                "listonosz": "mdi:truck-delivery",
+                "rower": "mdi:bike",
+                "skuter": "mdi:motorbike",
+                "motocykl": "mdi:motorbike",
+                "autobus": "mdi:bus",
+                "samochod": "mdi:car",
+                "dostawczak": "mdi:car",
+                "SUV": "mdi:car",
+                "pojazd": "mdi:car",
+                "ciezarowka": "mdi:truck",
+                "ulica": "mdi:road-variant",
+                "droga": "mdi:road-variant",
+                "podjazd": "mdi:road-variant"
+            }
+        },
+        "animals": {
+            "objects": {
+                "pies": "mdi:dog",
+                "kot": "mdi:cat",
+                "kotek": "mdi:cat",
+                "piesek": "mdi:dog",
+                "ptak": "mdi:duck",
+                "zwierze": "mdi:dog"
+            }
+        },
+        "packages": {
+            "objects": {
+                "pudelko": "mdi:package-variant-closed",
+                "paczka": "mdi:package-variant-closed",
+                "przesylka": "mdi:package-variant-closed",
+                "list": "mdi:email"
+            }
+        },
+        "entities": {
+            "objects": {
+                "kamera": "mdi:cctv",
+                "czujnik": "mdi:access-point",
+                "swiatlo": "mdi:lightbulb",
+                "klucz": "mdi:key",
+                "zamek": "mdi:lock",
+                "alarm": "mdi:alarm-light",
+                "dom": "mdi:home",
+                "weranda": "mdi:door-closed",
+                "drzwi": "mdi:door-closed",
+                "okno": "mdi:window-closed-variant",
+                "brama": "mdi:gate",
+                "bramy": "mdi:gate"
+            }
+        },
+        "nature": {
+            "objects": {
+                "ogrod": "mdi:flower",
+                "roslina": "mdi:flower",
+                "kwiat": "mdi:flower",
+                "drzewo": "mdi:tree"
+            }
+        }
+    },
+    "regex": ""
 };

--- a/dist/pl.js
+++ b/dist/pl.js
@@ -1,6 +1,7 @@
 export const pl = {
     "text": {
         "noEvents": "Brak aktywnosci",
+        "noEventsHours": "Brak aktywnosci w ostatnich {hours} godzinach",
         "today": "Dzis",
         "yesterday": "Wczoraj"
     },

--- a/dist/pt.js
+++ b/dist/pt.js
@@ -1,6 +1,7 @@
 export const pt = {
     "text": {
         "noEvents": "Nenhum Evento",
+        "noEventsHours": "Nenhum Evento nas últimas {hours} horas",
         "today": "Hoje",
         "yesterday": "Ontem"
     },

--- a/dist/sv.js
+++ b/dist/sv.js
@@ -1,6 +1,7 @@
 export const sv = {
     "text": {
         "noEvents": "Inga händelser",
+        "noEventsHours": "Inga händelser de senaste {hours} timmarna",
         "today": "Idag",
         "yesterday": "Igår"
     },

--- a/dist/sv.js
+++ b/dist/sv.js
@@ -1,0 +1,90 @@
+export const sv = {
+    "text": {
+        "noEvents": "Inga händelser",
+        "today": "Idag",
+        "yesterday": "Igår"
+    },
+    "categories": {
+        "people": {
+            "name": "Personer",
+            "objects": {
+                "person": "mdi:walk",
+                "individ": "mdi:walk",
+                "figur": "mdi:walk",
+                "personer": "mdi:walk",
+                "barn": "mdi:walk",
+                "kvinna": "mdi:walk",
+                "man": "mdi:walk",
+                "människa": "mdi:walk",
+                "folk": "mdi:walk",
+                "människor": "mdi:walk"
+            }
+        },
+        "vehicles": {
+            "name": "Fordon",
+            "objects": {
+                "kurir": "mdi:truck-delivery",
+                "brevbärare": "mdi:truck-delivery",
+                "cykel": "mdi:bike",
+                "motorcykel": "mdi:motorbike",
+                "moped": "mdi:motorbike",
+                "buss": "mdi:bus",
+                "bil": "mdi:car",
+                "skåpbil": "mdi:car",
+                "jeep": "mdi:car",
+                "fordon": "mdi:car",
+                "lastbil": "mdi:truck",
+                "gata": "mdi:road-variant",
+                "uppfart": "mdi:road-variant",
+                "väg": "mdi:road-variant"
+            }
+        },
+        "animals": {
+            "name": "Djur",
+            "objects": {
+                "hund": "mdi:dog",
+                "katt": "mdi:cat",
+                "fågel": "mdi:duck",
+                "husdjur": "mdi:dog",
+                "djur": "mdi:dog"
+            }
+        },
+        "packages": {
+            "name": "Paket",
+            "objects": {
+                "låda": "mdi:package-variant-closed",
+                "paket": "mdi:package-variant-closed",
+                "försändelse": "mdi:package-variant-closed",
+                "brev": "mdi:email",
+                "post": "mdi:email"
+            }
+        },
+        "entities": {
+            "name": "Enheter",
+            "objects": {
+                "kamera": "mdi:cctv",
+                "sensor": "mdi:access-point",
+                "ljus": "mdi:lightbulb",
+                "lampa": "mdi:lightbulb",
+                "nyckel": "mdi:key",
+                "lås": "mdi:lock",
+                "alarm": "mdi:alarm-light",
+                "hus": "mdi:home",
+                "bostad": "mdi:home",
+                "veranda": "mdi:door-closed",
+                "dörr": "mdi:door-closed",
+                "fönster": "mdi:window-closed-variant"
+            }
+        },
+        "nature": {
+            "name": "Natur",
+            "objects": {
+                "trädgård": "mdi:flower",
+                "växt": "mdi:flower",
+                "blomma": "mdi:flower",
+                "träd": "mdi:tree"
+            }
+        }
+    },
+    "regex": "`\\b${key}(en)?\\b`, 'i'"
+}

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
     "name": "llmvision-card",
-    "version": "1.4.2"
+    "version": "1.4.3"
 }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
     "name": "llmvision-card",
-    "version": "1.4.3"
+    "version": "1.4.2"
 }


### PR DESCRIPTION
- **Improved key frame selection for short events** to make sure the subject is always visible. (Requires integration update to `v1.4.2`). Thank you @lich2000117!
- **Added `number_of_hours`**. This is a new filter and can be used with or without the existing `number_of_events`. It is useful if you want to show only events from the last 24 hours. (#6)
- Images will now be shown in the **original resolution**. Thank you @sb-develop!
- Added 🇵🇹 **Portuguese** translations. Thank you @willianrod!
- Added 🇵🇱 **Polish** translations. Thank you @catpersec!
- Added 🇸🇪 **Swedish** translations. Thank you @adnansarajlic!
- Added 🇮🇹 Italian translations. Thank you @jetmcquack!
- Detail popup now closes on back button/gesture on Android.
- Added more supported icons