### PR TITLE
feat(i18n): add Czech (cs) translation

### DIFF
--- a/dist/cs.js
+++ b/dist/cs.js
@@ -1,0 +1,84 @@
+export const cs = {
+    "text": {
+        "noEvents": "Žádné události",
+        "noEventsHours": "Žádné události za posledních {hours} hodin",
+        "noEventsCamera": "Žádné události nenalezeny pro vybranou kameru/y",
+        "noEventsCategory": "Žádné události nenalezeny pro vybranou kategorii",
+        "today": "Dnes",
+        "yesterday": "Včera"
+    },
+    "categories": {
+        "people": {
+            "objects": {
+                "osoba": "mdi:walk",
+                "jednotlivec": "mdi:walk",
+                "postava": "mdi:walk",
+                "lidé": "mdi:walk",
+                "dítě": "mdi:walk",
+                "žena": "mdi:walk",
+                "muž": "mdi:walk",
+                "člověk": "mdi:walk",
+                "cyklista": "mdi:bike",
+            }
+        },
+        "vehicles": {
+            "objects": {
+                "kurýr": "mdi:truck-delivery",
+                "pošťák": "mdi:truck-delivery",
+                "kolo": "mdi:bike",
+                "bicykl": "mdi:bike",
+                "motocykl": "mdi:motorbike",
+                "motorka": "mdi:motorbike",
+                "autobus": "mdi:bus",
+                "auto": "mdi:car",
+                "dodávka": "mdi:car",
+                "suv": "mdi:car",
+                "vozidlo": "mdi:car",
+                "nákladní auto": "mdi:truck",
+                "ulice": "mdi:road-variant",
+                "chodník": "mdi:road-variant",
+                "příjezdová cesta": "mdi:road-variant"
+            }
+        },
+        "animals": {
+            "objects": {
+                "pes": "mdi:dog",
+                "kočka": "mdi:cat",
+                "pták": "mdi:duck",
+                "domácí zvíře": "mdi:dog",
+                "zvíře": "mdi:dog"
+            }
+        },
+        "packages": {
+            "objects": {
+                "krabice": "mdi:package-variant-closed",
+                "balík": "mdi:package-variant-closed",
+                "zásilka": "mdi:package-variant-closed",
+                "dopis": "mdi:email"
+            }
+        },
+        "entities": {
+            "objects": {
+                "kamera": "mdi:cctv",
+                "senzor": "mdi:access-point",
+                "světlo": "mdi:lightbulb",
+                "klíč": "mdi:key",
+                "zámek": "mdi:lock",
+                "alarm": "mdi:alarm-light",
+                "dům": "mdi:home",
+                "veranda": "mdi:door-closed",
+                "dveře": "mdi:door-closed",
+                "okno": "mdi:window-closed-variant"
+            }
+        },
+        "nature": {
+            "objects": {
+                "zahrada": "mdi:flower",
+                "rostlina": "mdi:flower",
+                "kytka": "mdi:flower",
+                "strom": "mdi:tree"
+            }
+        }
+    },
+    "regex": ""
+}

--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -9,6 +9,7 @@ import { pl } from './pl.js?v=1.5.1';
 import { pt } from './pt.js?v=1.5.1';
 import { sk } from './sk.js?v=1.5.1';
 import { sv } from './sv.js?v=1.5.1';
+import { cs } from './cs.js?v=1.5.1';
 
 export function hexToRgba(hex, alpha = 1) {
     let c = hex.replace('#', '');
@@ -46,6 +47,8 @@ export function getIcon(title, lang = 'en') {
             categories = sk.categories;
         } else if (lang === 'sv') {
             categories = sv.categories;
+        } else if (lang === 'cs') {
+            categories = cs.categories;
         } else {
             throw new Error(`Unsupported language: ${lang}`);
         }
@@ -79,6 +82,7 @@ const translations = {
     pt: pt.text,
     sk: sk.text,
     sv: sv.text,
+    cs: cs.text,
 };
 
 export function translate(key, language) {


### PR DESCRIPTION
This PR adds full Czech (cs) translation support.

- Added new file `dist/cs.js` with Czech translations
- Updated `helpers.js`:
  - Imported `cs`
  - Added `cs` support in getIcon()
  - Added `cs` to the translations map

Placeholders (e.g., {hours}) kept consistent with other locales.
