### PR TITLE
Use Timeline API

### DIFF
--- a/dist/card-base.js
+++ b/dist/card-base.js
@@ -254,11 +254,15 @@ export class BaseLLMVisionCard extends HTMLElement {
                         </div>` : ''}
                     </div>
                     <div class="${titleRowClass}">
-                        <ha-icon icon="${icon}"></ha-icon>
-                        <h2>${event}</h2>
+                        <div class="${prefix}-title-main">
+                            <ha-icon icon="${icon}"></ha-icon>
+                            <h2>${event}</h2>
+                        </div>
+                        <div class="${prefix}-title-secondary">
+                            <p class="secondary"><span>${secondaryText}</span></p>
+                        </div>
                     </div>
                     <img src="${keyFrame}" alt="Event Snapshot" onerror="this.style.display='none'">
-                    <p class="secondary"><span>${secondaryText}</span></p>
                     <p class="summary">${summary}</p>
                 </div>
             `;
@@ -312,19 +316,34 @@ export class BaseLLMVisionCard extends HTMLElement {
                     /* Title row: icon + title */
                     .${titleRowClass} {
                         display: flex;
+                        flex-direction: column;
                         align-items: center;
-                        justify-content: center; /* centered horizontally */
-                        gap: 10px;
+                        gap: 6px;
                         margin-bottom: 6px;
                     }
-                    .${titleRowClass} h2 {
+                    .${prefix}-title-main {
+                        display: flex;
+                        align-items: center;
+                        gap: 10px;
+                        justify-content: center;
+                    }
+                    .${prefix}-title-main h2 {
                         overflow: hidden;
                         text-overflow: ellipsis;
                         white-space: nowrap;
-                        /* flex: 1 1 auto; */ /* no stretch, keep content-sized for centering */
                         margin: 0;
                         font-family: var(--ha-font-family-heading, "Roboto");
                         text-align: center;
+                    }
+                    .${prefix}-title-secondary {
+                        width: 100%;
+                        text-align: center;
+                    }
+                    .${prefix}-title-secondary .secondary {
+                        font-weight: var(--ha-font-weight-medium, 500);
+                        margin-top: 4px;
+                        color: var(--primary-text-color);
+                        font-family: var(--ha-font-family-body, "Roboto");
                     }
     
                     /* Image and text */
@@ -333,11 +352,6 @@ export class BaseLLMVisionCard extends HTMLElement {
                         height: auto;
                         border-radius: calc(var(--ha-card-border-radius, 25px) - 10px);
                         margin-top: 10px;
-                    }
-                    .${contentClass} .secondary {
-                        font-weight: var(--ha-font-weight-medium, 500);
-                        color: var(--primary-text-color);
-                        font-family: var(--ha-font-family-body, "Roboto");
                     }
                     .${contentClass} .summary {
                         color: var(--secondary-text-color);

--- a/dist/card-base.js
+++ b/dist/card-base.js
@@ -52,10 +52,10 @@ export class BaseLLMVisionCard extends HTMLElement {
             if (cameras?.length) {
                 params.set('cameras', cameras.join(','));
             }
-            /*
-            if (this.category_filters?.length) {
-                params.set('categories', this.category_filters.join(','));
-            } */
+            if (days) params.set('days', days);
+            if (categories?.length) {
+                params.set('categories', categories.join(','));
+            }
 
             const path = `llmvision/timeline/events${params.toString() ? '?' + params.toString() : ''}`;
             const data = await hass.callApi('GET', path);
@@ -68,7 +68,8 @@ export class BaseLLMVisionCard extends HTMLElement {
                 return {
                     title: item.summary || '',
                     description: item.description || '',
-                    keyFrame: (item.key_frame || '').replace('/config/www/', '/local/'),
+                    category: item.category || '',
+                    keyFrame: (item.key_frame || ''),
                     cameraName: cameraFriendlyName,
                     startTime: item.start || null,
                     endTime: item.end || null,

--- a/dist/cs.js
+++ b/dist/cs.js
@@ -1,7 +1,7 @@
 export const cs = {
     "text": {
         "noEvents": "Žádné události",
-        "noEventsHours": "Žádné události za posledních {hours} hodin",
+        "noEventsDays": "Žádné události za posledních {days} dní",
         "noEventsCamera": "Žádné události nenalezeny pro vybranou kameru/y",
         "noEventsCategory": "Žádné události nenalezeny pro vybranou kategorii",
         "today": "Dnes",

--- a/dist/de.js
+++ b/dist/de.js
@@ -1,7 +1,7 @@
 export const de = {
     "text": {
         "noEvents": "Keine Ereignisse",
-        "noEventsHours": "Keine Ereignisse in den letzten {hours} Stunden",
+        "noEventsDays": "Keine Ereignisse in den letzten {days} Tagen",
         "noEventsCamera": "Keine Ereignisse für die ausgewählten Kameras gefunden.",
         "noEventsCategory": "Keine Ereignisse für die ausgewählte Kategorie gefunden.",
         "today": "Heute",

--- a/dist/en.js
+++ b/dist/en.js
@@ -1,7 +1,7 @@
 export const en = {
     "text": {
         "noEvents": "No events",
-        "noEventsHours": "No events in the last {hours} hours",
+        "noEventsDays": "No events in the last {days} days",
         "noEventsCamera": "No events found for the selected camera(s).",
         "noEventsCategory": "No events found for the selected category.",
         "today": "Today",

--- a/dist/es.js
+++ b/dist/es.js
@@ -1,7 +1,7 @@
 export const es = {
     "text": {
         "noEvents": "No hay eventos",
-        "noEventsHours": "No hay eventos en las últimas {hours} horas",
+        "noEventsDays": "No hay eventos en los últimos {days} días",
         "noEventsCamera": "No se encontraron eventos para la(s) cámara(s) seleccionada(s).",
         "noEventsCategory": "No se encontraron eventos para la(s) categoría(s) seleccionada(s).",
         "today": "Hoy",

--- a/dist/fr.js
+++ b/dist/fr.js
@@ -1,7 +1,7 @@
 export const fr = {
     "text": {
         "noEvents": "Aucun événement",
-        "noEventsHours": "Aucun événement dans les dernières {hours} heures",
+        "noEventsDays": "Aucun événement dans les derniers {days} jours",
         "noEventsCamera": "Aucun événement trouvé pour la(les) caméra(s) sélectionnée(s).",
         "noEventsCategory": "Aucun événement trouvé pour la(les) catégorie(s) sélectionnée(s).",
         "today": "Aujourd'hui",

--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -1,17 +1,17 @@
-import { colors } from './colors.js?v=1.5.2';
-import { ca } from './ca.js?v=1.5.2';
-import { de } from './de.js?v=1.5.2';
-import { en } from './en.js?v=1.5.2';
-import { es } from './es.js?v=1.5.2';
-import { fr } from './fr.js?v=1.5.2';
-import { it } from './it.js?v=1.5.2';
-import { nl } from './nl.js?v=1.5.2';
-import { pl } from './pl.js?v=1.5.2';
-import { pt } from './pt.js?v=1.5.2';
-import { sk } from './sk.js?v=1.5.2';
-import { sv } from './sv.js?v=1.5.2';
-import { hu } from './hu.js?v=1.5.2';
-import { cs } from './cs.js?v=1.5.2';
+import { colors } from './colors.js?v=1.6.0';
+import { ca } from './ca.js?v=1.6.0';
+import { de } from './de.js?v=1.6.0';
+import { en } from './en.js?v=1.6.0';
+import { es } from './es.js?v=1.6.0';
+import { fr } from './fr.js?v=1.6.0';
+import { it } from './it.js?v=1.6.0';
+import { nl } from './nl.js?v=1.6.0';
+import { pl } from './pl.js?v=1.6.0';
+import { pt } from './pt.js?v=1.6.0';
+import { sk } from './sk.js?v=1.6.0';
+import { sv } from './sv.js?v=1.6.0';
+import { hu } from './hu.js?v=1.6.0';
+import { cs } from './cs.js?v=1.6.0';
 
 export function hexToRgba(hex, alpha = 1) {
     let c = hex.replace('#', '');
@@ -25,7 +25,7 @@ export function hexToRgba(hex, alpha = 1) {
     return `rgba(${r},${g},${b},${alpha})`;
 }
 
-export function getIcon(title, lang = 'en') {
+export function getIcon(category) {
     let categories;
     let pluralRegex;
 

--- a/dist/hu.js
+++ b/dist/hu.js
@@ -1,7 +1,7 @@
 export const hu = {
     "text": {
         "noEvents": "Nincsenek események",
-        "noEventsHours": "Nincsenek események az elmúlt {hours} órában",
+        "noEventsDays": "Nincsenek események az elmúlt {days} napban",
         "noEventsCamera": "A kiválasztott kamerá(k)hoz nem tartoznak események.",
         "noEventsCategory": "A kiválasztott kategóriához nem tartoznak események.",
         "today": "Ma",

--- a/dist/it.js
+++ b/dist/it.js
@@ -1,7 +1,7 @@
 export const it = {
     "text": {
         "noEvents": "Nessun Evento",
-        "noEventsHours": "Nessun Evento nelle ultime {hours} ore",
+        "noEventsDays": "Nessun Evento nelle ultime {days} giorni",
         "noEventsCamera": "Nessun evento trovato per la(les) telecamera(e) selezionata(e).",
         "noEventsCategory": "Nessun evento trovato per la(les) categoria(e) selezionata(e).",
         "today": "Oggi",

--- a/dist/llmvision-card.js
+++ b/dist/llmvision-card.js
@@ -211,7 +211,8 @@ class LLMVisionCard extends BaseLLMVisionCard {
 
 
     async _loadAndRender(hass) {
-        let details = await this.fetchEvents(hass,
+        let details = await this.fetchEvents(
+            hass,
             this.number_of_events,
             this.number_of_days,
             this.camera_filters,

--- a/dist/llmvision-card.js
+++ b/dist/llmvision-card.js
@@ -211,7 +211,11 @@ class LLMVisionCard extends BaseLLMVisionCard {
 
 
     async _loadAndRender(hass) {
-        let details = await this.fetchEvents(hass);
+        let details = await this.fetchEvents(hass,
+            this.number_of_events,
+            this.number_of_days,
+            this.camera_filters,
+            this.category_filters);
         if (!details) return;
 
         const currentHash = this._hashState({
@@ -284,8 +288,9 @@ class LLMVisionCard extends BaseLLMVisionCard {
                         keyFrame: url,
                         cameraName: d.cameraName,
                         icon,
-                        prefix: 'popup'
-                    });
+                        prefix: 'popup',
+                        eventId: d.id
+                    }, hass);
                 });
             });
             this.content.appendChild(container);

--- a/dist/llmvision-preview-card.js
+++ b/dist/llmvision-preview-card.js
@@ -177,7 +177,8 @@ export class LLMVisionPreviewCard extends BaseLLMVisionCard {
     }
 
     async _loadAndRender(hass) {
-        let details = await this.fetchEvents(hass,
+        let details = await this.fetchEvents(
+            hass,
             1,
             this.number_of_days,
             this.camera_filters,

--- a/dist/llmvision-preview-card.js
+++ b/dist/llmvision-preview-card.js
@@ -177,7 +177,12 @@ export class LLMVisionPreviewCard extends BaseLLMVisionCard {
     }
 
     async _loadAndRender(hass) {
-        let details = await this.fetchEvents(hass);
+        let details = await this.fetchEvents(hass,
+            1,
+            this.number_of_days,
+            this.camera_filters,
+            this.category_filters
+        );
         if (!details) return;
 
         const currentHash = this._hashState({
@@ -189,8 +194,6 @@ export class LLMVisionPreviewCard extends BaseLLMVisionCard {
         });
         if (currentHash === this._lastEventHash) return;
         this._lastEventHash = currentHash;
-
-        console.log('Fetched events:', details);
 
         if (!details.length) {
             this.content.innerHTML = '';
@@ -204,7 +207,6 @@ export class LLMVisionPreviewCard extends BaseLLMVisionCard {
             this.content.innerHTML = `<div class="event-container" style="display:flex;align-items:center;justify-content:center;height:100%;"><h3>${msg}</h3></div>`;
             return;
         }
-        console.log('Rendering events:', details);
         this._render(details, hass);
     }
 
@@ -235,8 +237,9 @@ export class LLMVisionPreviewCard extends BaseLLMVisionCard {
                     keyFrame: url,
                     cameraName: event.cameraName,
                     icon,
-                    prefix: 'popup'
-                });
+                    prefix: 'popup',
+                    eventId: event.id
+                }, hass);
             });
         });
         this.content.innerHTML = '';

--- a/dist/llmvision-preview-card.js
+++ b/dist/llmvision-preview-card.js
@@ -154,7 +154,7 @@ export class LLMVisionPreviewCard extends BaseLLMVisionCard {
             this.content = this.querySelector('.preview-card-content');
         }
 
-        const raw = this._readCalendarAttributes(hass);
+        const raw = this.fetchEvents(hass);
         if (!raw) return;
 
         const currentHash = this._hashState({

--- a/dist/nl.js
+++ b/dist/nl.js
@@ -1,7 +1,7 @@
 export const nl = {
     "text": {
         "noEvents": "Geen evenementen",
-        "noEventsHours": "Geen evenementen in de afgelopen {hours} uur",
+        "noEventsDays": "Geen evenementen in de afgelopen {days} dagen",
         "noEventsCamera": "Geen evenementen gevonden voor de geselecteerde camera('s).",
         "noEventsCategory": "Geen evenementen gevonden voor de geselecteerde categorie.",
         "today": "Vandaag",

--- a/dist/pl.js
+++ b/dist/pl.js
@@ -1,7 +1,7 @@
 export const pl = {
     "text": {
         "noEvents": "Brak aktywnosci",
-        "noEventsHours": "Brak aktywnosci w ostatnich {hours} godzinach",
+        "noEventsDays": "Brak aktywnosci w ostatnich {days} dniach",
         "noEventsCamera": "Nie znaleziono aktywnosci dla wybranej kamery.",
         "noEventsCategory": "Nie znaleziono aktywnosci dla wybranej kategorii.",
         "today": "Dzis",

--- a/dist/pt.js
+++ b/dist/pt.js
@@ -1,7 +1,7 @@
 export const pt = {
     "text": {
         "noEvents": "Nenhum Evento",
-        "noEventsHours": "Nenhum Evento nas últimas {hours} horas",
+        "noEventsDays": "Nenhum Evento nas últimas {days} dias",
         "noEventsCamera": "Nenhum evento encontrado para a(s) câmera(s) selecionada(s).",
         "noEventsCategory": "Nenhum evento encontrado para a(s) categoria(s) selecionada(s).",
         "today": "Hoje",

--- a/dist/sk.js
+++ b/dist/sk.js
@@ -1,7 +1,7 @@
 export const sk = {
     "text": {
         "noEvents": "Žiadne udalosti",
-        "noEventsHours": "Žiadne udalosti za posledných {hours} hodín",
+        "noEventsDays": "Žiadne udalosti za posledných {days} dní",
         "noEventsCamera": "Žiadne udalosti nenájdené pre vybranú kameru(y).",
         "noEventsCategory": "Žiadne udalosti nenájdené pre vybranú kategóriu.",
         "today": "Dnes",

--- a/dist/sv.js
+++ b/dist/sv.js
@@ -1,7 +1,7 @@
 export const sv = {
     "text": {
         "noEvents": "Inga händelser",
-        "noEventsHours": "Inga händelser de senaste {hours} timmarna",
+        "noEventsDays": "Inga händelser de senaste {days} dagarna",
         "noEventsCamera": "Inga händelser hittades för den valda kameran/erna.",
         "noEventsCategory": "Inga händelser hittades för den valda kategorin.",
         "today": "Idag",


### PR DESCRIPTION
- Both timeline and preview cards now respect the Home Assistant layout editor dimensions.
- Timeline card is now scrollable

- Renamed `number_of_hours` to `number_of_days`

- Use new timeline API to fetch events directly from the db. This replaces the old "extra attributes" fetch strategy. With this, it is now possible to display more events (currently up to 100) in the timeline card.
- Moved event categorization to backend