### PR TITLE
Fix Italian and Polish translation formatting and diacritics

### DIFF
--- a/dist/translations.js
+++ b/dist/translations.js
@@ -82,8 +82,8 @@ export const it = {
     "text": {
         "noEvents": "Nessun Evento",
         "noEventsDays": "Nessun Evento nelle ultime {days} giorni",
-        "noEventsCamera": "Nessun evento trovato per la(les) telecamera(e) selezionata(e).",
-        "noEventsCategory": "Nessun evento trovato per la(les) categoria(e) selezionata(e).",
+        "noEventsCamera": "Nessun evento trovato per la/le telecamera/e selezionata/e.",
+        "noEventsCategory": "Nessun evento trovato per la/le categoria/e selezionata/e.",
         "today": "Oggi",
         "yesterday": "Ieri"
     }
@@ -100,11 +100,11 @@ export const nl = {
 }
 export const pl = {
     "text": {
-        "noEvents": "Brak aktywnosci",
-        "noEventsDays": "Brak aktywnosci w ostatnich {days} dniach",
-        "noEventsCamera": "Nie znaleziono aktywnosci dla wybranej kamery.",
-        "noEventsCategory": "Nie znaleziono aktywnosci dla wybranej kategorii.",
-        "today": "Dzis",
+        "noEvents": "Brak aktywności",
+        "noEventsDays": "Brak aktywności w ostatnich {days} dniach",
+        "noEventsCamera": "Nie znaleziono aktywności dla wybranej kamery.",
+        "noEventsCategory": "Nie znaleziono aktywności dla wybranej kategorii.",
+        "today": "Dziś",
         "yesterday": "Wczoraj"
     }
 }


### PR DESCRIPTION
## Summary
This PR corrects translation strings in Italian and Polish locales to improve grammar, formatting, and proper use of diacritical marks.

## Key Changes
- **Italian translations**: Updated `noEventsCamera` and `noEventsCategory` messages to use proper slash notation (e.g., "la/le" instead of "la(les)") for more natural grammar
- **Polish translations**: 
  - Fixed diacritical marks: "aktywnosci" → "aktywności" and "Dzis" → "Dziś"
  - Applied the corrected spelling across all related translation keys (`noEvents`, `noEventsDays`, `noEventsCamera`, `noEventsCategory`, and `today`)

## Implementation Details
These are purely translation content updates with no functional code changes. The modifications ensure proper localization standards and improve readability for Italian and Polish users.

https://claude.ai/code/session_01PTRg4LPiVSFkjYyTdN6fZ6