### PR TITLE
Fix no activity filter

### DIFF
--- a/dist/card-base.js
+++ b/dist/card-base.js
@@ -99,8 +99,8 @@ export class BaseLLMVisionCard extends HTMLElement {
     }
 
     _filterNoActivity(details) {
-        return details.filter((d) => (d?.title || '').trim().toLowerCase() !== 'no activity observed');
-    }    
+        return details.filter((d) => (d?.description || '').trim().toLowerCase() !== 'no activity observed.');
+    }
 
     _filterByHours(details, hours) {
         if (!hours) return details;


### PR DESCRIPTION
Hiya! Thanks for the work on this plugin, it's made some of the stuff I was doing way way easier, haha.

I noticed that filtering no activity in the card wasn't working correctly, started poking around a bit to see why.

The titles generated by the actual integration are often more than just "No activity detected", but the default description generated by the plugin is "No activity detected." Detect that instead to filter out events that are unimportant. Since this card was filtering based on a title -> tolower equal "no activity detected", that filter was always false. Could probably also do this with regex against the title, but that seemed silly to me when the description is always set explicitly when nothing's detected.

Cheers!